### PR TITLE
Update album-audio.html to add a failsafe on concurrency

### DIFF
--- a/quickfixes-yggland/nfo/album-audio.html
+++ b/quickfixes-yggland/nfo/album-audio.html
@@ -214,6 +214,7 @@
 					onChangeFile(e.dataTransfer.files);
 				});
 
+				concurrencyInput.value = Math.min(concurrencyInput.value, navigator.hardwareConcurrency);
 				concurrencyInput.setAttribute("max", navigator.hardwareConcurrency);
 
 				const onChangeFile = async (inputFiles) => {


### PR DESCRIPTION
If the hardware concurrency value is inferior to the default concurrency value, use it instead.